### PR TITLE
Changed the night version of townhall to use proper graphics

### DIFF
--- a/scripts/entity/world/settlements/buildings/stronghold_management_building.nut
+++ b/scripts/entity/world/settlements/buildings/stronghold_management_building.nut
@@ -10,7 +10,7 @@ this.stronghold_management_building <- this.inherit("scripts/entity/world/settle
 		this.m.Name = "Management";
 		this.m.Description = "Manage your base";
 		this.m.UIImage = "ui/settlements/stronghold_01_management";
-		this.m.UIImageNight = "ui/settlements/building_06";
+		this.m.UIImageNight = "ui/settlements/stronghold_01_night_management";
 		this.m.Tooltip = "world-town-screen.main-dialog-module.Management";
 		this.m.TooltipIcon = "ui/icons/buildings/tavern.png";
 		this.m.IsClosedAtNight = false;


### PR DESCRIPTION
Instead of the marketplace (building_06) it should probably use the appropriate _night gfx that exists

Test plan:
- go into town while day
- verify
- go into town while at night
- verify

Before fix:
- go into town while day
- normal tower will be shown
- go into town while at night
- marketplace will be showing instead of the town hall

After fix:
- go into town while day
- normal tower will be shown
- go into town while at night
- normal (night) tower will be shown

## Screenshots:

# before

![Battle Brothers 1 4 0 49 2_21_2022 0_17_31](https://user-images.githubusercontent.com/7498356/154868820-3a10046f-8272-4c1a-bcef-c58698d047c8.png)

# after
![Battle Brothers 1 4 0 49 2_21_2022 0_16_35](https://user-images.githubusercontent.com/7498356/154868831-8e5eb959-1a29-4b4c-b1aa-3cee76dde12d.png)

